### PR TITLE
feat(auth): Return email in login response

### DIFF
--- a/src/main/java/com/igrowker/feature/parkify/features/auth/controller/AuthController.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/controller/AuthController.java
@@ -38,27 +38,45 @@ public class AuthController {
     // #16
     @Operation(
             summary = "Login User (#16)",
-            description = "Authenticates a user based on email and password, returning a JWT token upon success."
+            description = "Authenticates a user (owner) based on email and password, returning a JWT" +
+                    " token and the user's email upon success."
     )
-    @io.swagger.v3.oas.annotations.parameters.RequestBody( // Явное описание RequestBody
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = "User credentials for login",
             required = true,
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = LoginRequest.class))
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = LoginRequest.class)
+            )
     )
-    @ApiResponse(responseCode = "200", description = "Authentication successful",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = LoginResponse.class)))
-    @ApiResponse(responseCode = "400", description = "Invalid request body (e.g., missing fields, invalid email format)",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
-    @ApiResponse(responseCode = "401", description = "Authentication failed (Invalid credentials)",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
+    @ApiResponse(
+            responseCode = "200",
+            description = "Authentication successful",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = LoginResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid request body (e.g., missing fields, invalid email format)",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "401",
+            description = "Authentication failed (Invalid credentials)",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)
+            )
+    )
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
-        final String token = authService.login(request);
-        return ResponseEntity.ok(new LoginResponse(token));
+        final LoginResponse loginResponse = authService.login(request);
+        return ResponseEntity.ok(loginResponse);
     }
 
     // #14, #15
@@ -81,7 +99,7 @@ public class AuthController {
             content = @Content(mediaType = "application/json")
     )
     @PostMapping("/register")
-    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request){
+    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
         final RegisterResponse response = authService.register(request);
         final URI location = uriBuilderService.buildUserLocationUri(response.getToken());
         return ResponseEntity.created(location)
@@ -91,14 +109,25 @@ public class AuthController {
     // #12, #17, #18
     @Operation(
             summary = "Get Current User Details",
-            description = "Retrieves details of the currently authenticated user based on the JWT token. Related to tasks #17, #18."
+            description = "Retrieves details of the currently authenticated user based on the " +
+                    "JWT token. Related to tasks #17, #18."
     )
-    @ApiResponse(responseCode = "200", description = "User details retrieved successfully",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = UserResponse.class)))
-    @ApiResponse(responseCode = "401", description = "Unauthorized (Missing or invalid JWT token)",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
+    @ApiResponse(
+            responseCode = "200",
+            description = "User details retrieved successfully",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = UserResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized (Missing or invalid JWT token)",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)
+            )
+    )
     @GetMapping("/me")
     public ResponseEntity<UserResponse> getCurrentUser(Authentication authentication) {
         final UserResponse userResponse = authService

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/dto/response/LoginResponse.java
@@ -1,12 +1,19 @@
 package com.igrowker.feature.parkify.features.auth.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class LoginResponse {
-    private String token;
-}
+@Schema(description = "Response after successful login, containing JWT token, user email, and role")
+public record LoginResponse(
+
+        @Schema(
+                description = "JWT token for authenticated session",
+                example = "eyJhbGciOiJIUzI1NiJ9..."
+        )
+        String token,
+
+        @Schema(
+                description = "Email of the logged-in user",
+                example = "owner@example.com"
+        )
+        String email
+) {}

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthService.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthService.java
@@ -3,11 +3,12 @@ package com.igrowker.feature.parkify.features.auth.service;
 
 import com.igrowker.feature.parkify.features.auth.dto.request.LoginRequest;
 import com.igrowker.feature.parkify.features.auth.dto.request.RegisterRequest;
+import com.igrowker.feature.parkify.features.auth.dto.response.LoginResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.RegisterResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.UserResponse;
 
 public interface AuthService {
-    String login(LoginRequest request);
+    LoginResponse login(LoginRequest request);
     RegisterResponse register(RegisterRequest request);
     UserResponse getCurrentUserDetails(String email);
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthServiceImpl.java
@@ -2,6 +2,7 @@ package com.igrowker.feature.parkify.features.auth.service;
 
 import com.igrowker.feature.parkify.features.auth.dto.request.LoginRequest;
 import com.igrowker.feature.parkify.features.auth.dto.request.RegisterRequest;
+import com.igrowker.feature.parkify.features.auth.dto.response.LoginResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.RegisterResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.UserResponse;
 import com.igrowker.feature.parkify.features.auth.entities.AuthUser;
@@ -30,7 +31,8 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public String login(LoginRequest request) {
+    @Transactional(readOnly = true)
+    public LoginResponse login(LoginRequest request) {
         final UserDetails userDetails = (UserDetails) authenticationManager.authenticate(
                         new UsernamePasswordAuthenticationToken(
                                 request.email(),
@@ -38,7 +40,9 @@ public class AuthServiceImpl implements AuthService {
                         )
                 )
                 .getPrincipal();
-        return jwtService.generateToken(userDetails);
+        final String email = userDetails.getUsername();
+        final String token = jwtService.generateToken(userDetails);
+        return new LoginResponse(token, email);
     }
 
     @Override

--- a/src/test/java/com/igrowker/feature/parkify/features/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/igrowker/feature/parkify/features/auth/controller/AuthControllerTest.java
@@ -40,27 +40,23 @@ class AuthControllerTest {
 
     private LoginRequest loginRequest;
     private final String testToken = "mockJwtToken123";
+    private final String testEmail = "test@example.com";
     private RegisterRequest registerRequest;
-    private RegisterResponse registerResponse;
 
     @BeforeEach
     void setUp() {
-        loginRequest = new LoginRequest("test@example.com", "password");
+        loginRequest = new LoginRequest(testEmail, "password");
 
         registerRequest = new RegisterRequest(
                 "kris", "kris@example.com", "Password",
                 "role", "0123456789"
                 );
-
-        registerResponse = new RegisterResponse(
-                "Token123"
-
-        );
     }
 
     @Test
     void login_Success_ShouldReturnOkWithToken() {
-        when(authService.login(any(LoginRequest.class))).thenReturn(testToken);
+        when(authService.login(any(LoginRequest.class)))
+                .thenReturn(new LoginResponse(testToken, testEmail));
 
         final ResponseEntity<LoginResponse> response = authController.login(loginRequest);
 
@@ -68,7 +64,7 @@ class AuthControllerTest {
                 () -> assertNotNull(response),
                 () -> assertEquals(HttpStatus.OK, response.getStatusCode()),
                 () -> assertNotNull(response.getBody()),
-                () -> assertEquals(testToken, response.getBody().getToken())
+                () -> assertEquals(testToken, response.getBody().token())
         );
         verify(authService, times(1)).login(loginRequest);
     }

--- a/src/test/java/com/igrowker/feature/parkify/features/auth/controller/AuthControllerWebLayerTest.java
+++ b/src/test/java/com/igrowker/feature/parkify/features/auth/controller/AuthControllerWebLayerTest.java
@@ -2,12 +2,18 @@ package com.igrowker.feature.parkify.features.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igrowker.feature.parkify.common.service.UriBuilderService;
+import com.igrowker.feature.parkify.exception.GlobalExceptionHandler;
 import com.igrowker.feature.parkify.features.auth.dto.request.LoginRequest;
+import com.igrowker.feature.parkify.features.auth.dto.response.LoginResponse;
 import com.igrowker.feature.parkify.features.auth.security.JwtService;
 import com.igrowker.feature.parkify.features.auth.security.SecurityConfig;
 import com.igrowker.feature.parkify.features.auth.service.AuthService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -18,6 +24,9 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,43 +37,57 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AuthController.class)
-@Import({JwtService.class, SecurityConfig.class})
+@Import({SecurityConfig.class, JwtService.class, GlobalExceptionHandler.class})
 @TestPropertySource(properties = {
         "jwt.secret=TXlUZXN0U2VjcmV0S2V5VGhhdElzTG9uZ0Vub3VnaDEyMw=="
 })
 class AuthControllerWebLayerTest {
+
     private final String testToken = "webLayerTestJwtToken789";
+    private final String testEmail = "test.web@example.com";
+
     @Autowired
     private MockMvc mockMvc;
+
     @Autowired
     private ObjectMapper objectMapper;
+
     @MockBean
     private AuthService authService;
+
     @MockBean
     UserDetailsService userDetailsService;
-    private LoginRequest loginRequest;
+
     @MockBean
     private UriBuilderService uriBuilderService;
 
+    private LoginRequest loginRequest;
+    private LoginResponse expectedLoginResponse;
+
     @BeforeEach
     void setUp() {
-        loginRequest = new LoginRequest("test.wed@example.com", "goodpassword");
+        loginRequest = new LoginRequest(testEmail, "goodpassword");
+        expectedLoginResponse = new LoginResponse(testToken, testEmail);
     }
 
     @Test
-    void login_ValidCredentials_ShouldReturnOkAndToken() throws Exception {
-        when(authService.login(any(LoginRequest.class))).thenReturn(testToken);
+    @DisplayName("POST /login with valid credentials should return OK, Token and Email")
+    void login_ValidCredentials_ShouldReturnOkAndTokenAndEmail() throws Exception {
+        when(authService.login(any(LoginRequest.class))).thenReturn(expectedLoginResponse);
 
         mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.token").value(testToken));
+                .andExpect(jsonPath("$.token", is(testToken)))
+                .andExpect(jsonPath("$.email", is(testEmail)));
+
         verify(authService, times(1)).login(loginRequest);
     }
 
     @Test
+    @DisplayName("POST /login with invalid credentials should return Unauthorized")
     void login_InvalidCredentials_ShouldReturnUnauthorized() throws Exception {
         when(authService.login(any(LoginRequest.class)))
                 .thenThrow(new BadCredentialsException("Invalid credentials provided"));
@@ -73,26 +96,34 @@ class AuthControllerWebLayerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isUnauthorized());
+
         verify(authService, times(1)).login(loginRequest);
     }
 
-    @Test
-    void login_InvalidRequestBody_MissingEmail_ShouldReturnBadRequest() throws Exception {
-        final LoginRequest invalidRequest = new LoginRequest("", "password");
+    @ParameterizedTest(name = "[{index}] POST /login with invalid body (email={0}, password={1}) should return Bad Request")
+    @MethodSource("invalidLoginArgumentsProvider")
+    @DisplayName("POST /login with various invalid request bodies should return Bad Request")
+    void login_InvalidRequestBody_ShouldReturnBadRequest(String email, String password) throws Exception {
+        final LoginRequest invalidRequest = new LoginRequest(email, password);
 
         mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidRequest)))
                 .andExpect(status().isBadRequest());
+
+        verify(authService, times(0)).login(any(LoginRequest.class));
     }
 
-    @Test
-    void login_InvalidRequestBody_MissingPassword_ShouldReturnBadRequest() throws Exception {
-        final LoginRequest invalidRequest = new LoginRequest("test@example.com", null);
+    private static Stream<Arguments> invalidLoginArgumentsProvider() {
+        final String validEmail = "test@example.com";
+        final String validPassword = "password123";
 
-        mockMvc.perform(post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidRequest)))
-                .andExpect(status().isBadRequest());
+        return Stream.of(
+                Arguments.of(null, validPassword),
+                Arguments.of("", validPassword),
+                Arguments.of("invalid-email", validPassword),
+                Arguments.of(validEmail, null),
+                Arguments.of(validEmail, "")
+        );
     }
 }


### PR DESCRIPTION
Este PR modifica el endpoint de login (`POST /api/v1/auth/login`) para que la respuesta incluya el **email** del usuario autenticado junto con el token JWT.

**Motivación**

El equipo de frontend solicitó incluir el email en la respuesta del login para poder acceder a él inmediatamente después de la autenticación, sin necesidad de realizar una llamada adicional al endpoint `/me`. Esto simplifica la lógica del frontend y mejora la experiencia inicial del usuario.

**Cambios Principales**

*   Se actualizó el DTO `LoginResponse` para añadir el campo `email`.
*   Se modificó la interfaz `AuthService` y la implementación `AuthServiceImpl` para que el método `login` devuelva el nuevo `LoginResponse`.
*   Se actualizaron los tests unitarios, de capa web e integración relacionados con el login para reflejar el nuevo formato de respuesta

===
This PR modifies the login endpoint (`POST /api/v1/auth/login`) so that the response includes the authenticated user's **email** along with the JWT token.

**Motivation**

The frontend team requested the inclusion of the email in the login response to access it immediately after authentication, without needing an additional call to the `/me` endpoint. This simplifies frontend logic and improves the initial user experience.

**Main Changes**

*   Updated the `LoginResponse` DTO to add the `email` field.
*   Modified the `AuthService` interface and `AuthServiceImpl` implementation for the `login` method to return the new `LoginResponse`.
*   Updated unit, web layer, and integration tests related to login to reflect the new response format.