### PR TITLE
feat(parking): Add parkingPhone and parkingImageUrl fields

### DIFF
--- a/src/main/java/com/igrowker/feature/parkify/features/parking/dto/request/CreateMyParkingRequest.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/dto/request/CreateMyParkingRequest.java
@@ -8,9 +8,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Data
 @Builder
 @NoArgsConstructor
@@ -33,4 +30,6 @@ public class CreateMyParkingRequest {
     @PositiveOrZero(message = "Hourly rate must be zero or positive")
     private Double hourlyRate;
     private String workingHours;
+    private String parkingPhone;
+    private String parkingImageUrl;
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/dto/response/ParkingDetailsResponse.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/dto/response/ParkingDetailsResponse.java
@@ -23,4 +23,6 @@ public class ParkingDetailsResponse {
     private Double hourlyRate;
     private String workingHours;
     private String ownerId;
+    private String parkingPhone;
+    private String parkingImageUrl;
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/dto/response/ParkingResponse.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/dto/response/ParkingResponse.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Data
 @Builder
 @NoArgsConstructor
@@ -24,4 +22,6 @@ public class ParkingResponse {
     private Double hourlyRate;
     private String workingHours;
     private Long ownerId;
+    private String parkingPhone;
+    private String parkingImageUrl;
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/dto/response/ParkingSummaryResponse.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/dto/response/ParkingSummaryResponse.java
@@ -2,8 +2,6 @@ package com.igrowker.feature.parkify.features.parking.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.igrowker.feature.parkify.features.parking.dto.LocationDto;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -22,7 +20,7 @@ public class ParkingSummaryResponse {
     private Double distance;
     private Integer currentAvailability;
     private Double hourlyRate;
+    private String parkingPhone;
+    private String parkingImageUrl;
 
-    public ParkingSummaryResponse(Long id, String name, String address, Double latitude, Double longitude, @NotNull @PositiveOrZero Double hourlyRate) {
-    }
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/entities/Parking.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/entities/Parking.java
@@ -54,5 +54,9 @@ public class Parking {
     @NotNull
     @Column(name = "owner_id", nullable = false)
     private Long ownerId;
+    @Column(name = "parking_phone")
+    private String parkingPhone;
+    @Column(name = "parking_image_url")
+    private String parkingImageUrl;
 
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceImpl.java
@@ -95,18 +95,7 @@ public class ParkingServiceImpl implements ParkingService {
                 .orElseThrow(() -> new OwnerNotFoundException(
                         "Owner not found with id: " + parking.getOwnerId()
                 ));
-        return ParkingDetailsResponse.builder()
-                .id(parking.getId().toString())
-                .name(parking.getName())
-                .address(parking.getAddress())
-                .location(new LocationDto(parking.getLatitude(), parking.getLongitude()))
-                .description(parking.getDescription())
-                .capacity(parking.getCapacity())
-                .currentAvailability(ofNullable(parking.getAvailableSpots()).orElse(0))
-                .hourlyRate(parking.getHourlyRate())
-                .workingHours(parking.getWorkingHours())
-                .ownerId(owner.getId().toString())
-                .build();
+        return mapParkingToDetailsResponse(parking, owner);
     }
 
     @Override
@@ -127,6 +116,8 @@ public class ParkingServiceImpl implements ParkingService {
                 .workingHours(request.getWorkingHours())
                 .ownerId(owner.getId())
                 .availableSpots(request.getCapacity())
+                .parkingPhone(request.getParkingPhone())
+                .parkingImageUrl(request.getParkingImageUrl())
                 .build();
         final Parking savedParking = parkingRepository.save(parking);
 
@@ -202,6 +193,8 @@ public class ParkingServiceImpl implements ParkingService {
                             .hourlyRate(p.getHourlyRate())
                             .currentAvailability(availability)
                             .distance(pwd.distance())
+                            .parkingPhone(p.getParkingPhone())
+                            .parkingImageUrl(p.getParkingImageUrl())
                             .build();
                 })
                 .toList();
@@ -267,6 +260,8 @@ public class ParkingServiceImpl implements ParkingService {
                 .hourlyRate(parking.getHourlyRate())
                 .workingHours(parking.getWorkingHours())
                 .ownerId(owner.getId())
+                .parkingPhone(parking.getParkingPhone())
+                .parkingImageUrl(parking.getParkingImageUrl())
                 .build();
     }
 
@@ -318,6 +313,8 @@ public class ParkingServiceImpl implements ParkingService {
                 .hourlyRate(parking.getHourlyRate())
                 .workingHours(parking.getWorkingHours())
                 .ownerId(owner.getId().toString())
+                .parkingPhone(parking.getParkingPhone())
+                .parkingImageUrl(parking.getParkingImageUrl())
                 .build();
     }
 


### PR DESCRIPTION
Este PR añade los campos `parkingPhone` (String) y `parkingImageUrl` (String) a la entidad `Parking` y a los DTOs relacionados (solicitudes y respuestas).

**Motivación**

Permitir el almacenamiento y la recuperación de un número de teléfono de contacto específico y una URL de imagen para cada estacionamiento, según los requisitos funcionales emergentes.

**Cambios Principales**

*   Actualizada la entidad `Parking`.
*   Actualizados los DTOs: `CreateMyParkingRequest`, `ParkingResponse`, `ParkingDetailsResponse`, `ParkingSummaryResponse`.
*   Actualizada la lógica de mapeo en `ParkingServiceImpl` para incluir los nuevos campos en las operaciones de creación y lectura.
*   Actualizadas las pruebas (unitarias, de capa web, integración) para incorporar los nuevos campos en las solicitudes y validaciones de respuestas.
===

This PR adds the `parkingPhone` (String) and `parkingImageUrl` (String) fields to the `Parking` entity and related DTOs (requests and responses).

**Motivation**

To allow storing and retrieving a specific contact phone number and an image URL for each parking facility, as per emerging functional requirements.

**Main Changes**

*   Updated the `Parking` entity.
*   Updated DTOs: `CreateMyParkingRequest`, `ParkingResponse`, `ParkingDetailsResponse`, `ParkingSummaryResponse`.
*   Updated mapping logic in `ParkingServiceImpl` to include the new fields in creation and read operations.
*   Updated tests (unit, web layer, integration) to incorporate the new fields in requests and response validations.