### PR TITLE
feat(parking): Implement PATCH /my/availability for owners

### DIFF
--- a/src/main/java/com/igrowker/feature/parkify/features/auth/security/SecurityConfig.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/security/SecurityConfig.java
@@ -45,11 +45,12 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 antMatcher(HttpMethod.POST, PARKINGS_PATH + "/my"),
-                                antMatcher(HttpMethod.GET, PARKINGS_PATH + "/my"), // <-- Наше правило
+                                antMatcher(HttpMethod.GET, PARKINGS_PATH + "/my"),
                                 antMatcher(HttpMethod.PATCH, PARKINGS_PATH + "/my/availability"),
                                 antMatcher(HttpMethod.PUT, PARKINGS_PATH + "/{parkingId}/features/{featureSlug}"),
                                 antMatcher(HttpMethod.DELETE, PARKINGS_PATH + "/{parkingId}/features/{featureSlug}"),
-                                antMatcher(HttpMethod.GET, PARKINGS_PATH + "/owner/parking") // Если остается
+                                antMatcher(HttpMethod.GET, PARKINGS_PATH + "/owner/parking"),
+                                antMatcher(HttpMethod.PATCH, "/api/v1/parkings/my/availability")
                         ).hasRole(OWNER_ROLE)
                         .requestMatchers(
                                 antMatcher(HttpMethod.POST, BOOKINGS_PATH)

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/controller/ParkingController.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/controller/ParkingController.java
@@ -173,7 +173,7 @@ public class ParkingController {
     @ApiResponse(responseCode = "404", description = "Parking facility not found with the ID provided in the request body (`parkingId`).",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                     schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
-//    @Deprecated(since = "2025.04.10")
+    @Deprecated(since = "2025.04.24")
     @PutMapping("/update-availability")
     public ResponseEntity<ParkingResponse> updateAvailability(
             @RequestBody ParkingRequest request) {
@@ -251,14 +251,32 @@ public class ParkingController {
     // #27
     @Operation(
             summary = "Update parking availability",
-            description = "Allows the authenticated owner to update the number of available spots in their parking."
+            description = "Allows the authenticated owner to update the number of available spots " +
+                    "in their parking."
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Availability updated successfully",
-                    content = @Content(schema = @Schema(implementation = ParkingAvailabilityResponse.class))),
-            @ApiResponse(responseCode = "400", description = "Invalid request data", content = @Content),
-            @ApiResponse(responseCode = "401", description = "Unauthorized or invalid JWT token", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Owner or parking not found", content = @Content)
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Availability updated successfully",
+                    content = @Content(schema = @Schema(
+                            implementation = ParkingAvailabilityResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request data",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized or invalid JWT token",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Owner or parking not found",
+                    content = @Content
+            )
     })
     @PatchMapping("/my/availability")
     public ResponseEntity<ParkingAvailabilityResponse> updateMyParkingAvailability(

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/dto/request/UpdateAvailabilityRequest.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/dto/request/UpdateAvailabilityRequest.java
@@ -1,9 +1,15 @@
 package com.igrowker.feature.parkify.features.parking.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
 public record UpdateAvailabilityRequest(
+        @Schema(
+                description = "The new number of available spots",
+                example = "15",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         @NotNull(message = "Available spots cannot be null")
         @PositiveOrZero(message = "Available spots must be zero or positive")
         Integer availableSpots

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingService.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingService.java
@@ -1,5 +1,6 @@
 package com.igrowker.feature.parkify.features.parking.service;
 
+import com.igrowker.feature.parkify.exception.OwnerNotFoundException;
 import com.igrowker.feature.parkify.exception.ParkingNotFoundException;
 import com.igrowker.feature.parkify.features.parking.dto.request.CreateMyParkingRequest;
 import com.igrowker.feature.parkify.features.parking.dto.request.ParkingRequest;
@@ -15,8 +16,6 @@ import org.springframework.data.domain.Pageable;
 public interface ParkingService {
 
     ParkingResponse createParking(ParkingRequest request);
-
-    ParkingResponse updateAvailability(ParkingRequest request);
 
     OwnerParkingDetailsResponse getOwnerWithParking(String ownerEmail);
 
@@ -39,6 +38,19 @@ public interface ParkingService {
             int limit, int offset, Pageable pageable
     );
 
+    @Deprecated(since = "2045-04-24")
+    ParkingResponse updateAvailability(ParkingRequest request);
+
+    /**
+     * Updates the available spots for the parking associated with the given owner.
+     *
+     * @param ownerEmail The email of the authenticated owner.
+     * @param availableSpots The new number of available spots. Must be not null and non-negative.
+     * @return A DTO containing the updated availability information.
+     * @throws OwnerNotFoundException if the owner is not found.
+     * @throws ParkingNotFoundException if the owner has no associated parking.
+     * @throws IllegalArgumentException if availableSpots is negative or exceeds capacity (optional check).
+     */
     ParkingAvailabilityResponse updateMyParkingAvailability(
             String ownerEmail,
             @NotNull(message = "Available spots cannot be null")

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceImpl.java
@@ -31,6 +31,7 @@ import static java.util.Optional.ofNullable;
 @RequiredArgsConstructor
 public class ParkingServiceImpl implements ParkingService {
 
+    private static final String AUTHENTICATED_OWNER_NOT_FOUND_WITH_EMAIL = "Authenticated owner not found with email: ";
     private final ParkingRepository parkingRepository;
     private final AuthUserRepository authUserRepository;
 
@@ -114,7 +115,7 @@ public class ParkingServiceImpl implements ParkingService {
     public ParkingResponse createMyParking(@Valid CreateMyParkingRequest request, String ownerEmail) {
         final AuthUser owner = authUserRepository.findByEmail(ownerEmail)
                 .orElseThrow(() -> new OwnerNotFoundException(
-                        "Authenticated owner not found with email: " + ownerEmail
+                        AUTHENTICATED_OWNER_NOT_FOUND_WITH_EMAIL + ownerEmail
                 ));
         final Parking parking = Parking.builder()
                 .name(request.getName())
@@ -226,10 +227,30 @@ public class ParkingServiceImpl implements ParkingService {
 
 
     @Override
+    @Transactional
     public ParkingAvailabilityResponse updateMyParkingAvailability(
-            String ownerEmail, Integer availableSpots
+            String ownerEmail,
+            Integer availableSpots
     ) {
-        return null;
+        final AuthUser owner = authUserRepository.findByEmail(ownerEmail)
+                .orElseThrow(() -> new OwnerNotFoundException(
+                        AUTHENTICATED_OWNER_NOT_FOUND_WITH_EMAIL + ownerEmail
+                ));
+        final Parking parking = parkingRepository.findByOwnerId(owner.getId())
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new ParkingNotFoundException(
+                        "Parking not found for owner with email: " + ownerEmail
+                ));
+        if (availableSpots > parking.getCapacity()) {
+            throw new IllegalArgumentException(
+                    String.format("Available spots (%d) cannot exceed capacity (%d)",
+                            availableSpots, parking.getCapacity())
+            );
+        }
+        parking.setAvailableSpots(availableSpots);
+        parkingRepository.save(parking);
+        return new ParkingAvailabilityResponse(parking.getId(), parking.getAvailableSpots());
     }
 
     @Override
@@ -237,7 +258,7 @@ public class ParkingServiceImpl implements ParkingService {
     public ParkingDetailsResponse getMyParkingDetails(String ownerEmail) {
         final AuthUser owner = authUserRepository.findByEmail(ownerEmail)
                 .orElseThrow(() -> new OwnerNotFoundException(
-                        "Authenticated owner not found with email: " + ownerEmail
+                        AUTHENTICATED_OWNER_NOT_FOUND_WITH_EMAIL + ownerEmail
                 ));
 
         final List<Parking> parkings = parkingRepository.findByOwnerId(owner.getId());

--- a/src/test/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceUpdateAvailabilityTest.java
+++ b/src/test/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceUpdateAvailabilityTest.java
@@ -1,0 +1,189 @@
+package com.igrowker.feature.parkify.features.parking.service;
+
+import com.igrowker.feature.parkify.exception.OwnerNotFoundException;
+import com.igrowker.feature.parkify.exception.ParkingNotFoundException;
+import com.igrowker.feature.parkify.features.auth.entities.AuthUser;
+import com.igrowker.feature.parkify.features.auth.repository.AuthUserRepository;
+import com.igrowker.feature.parkify.features.parking.dto.response.ParkingAvailabilityResponse;
+import com.igrowker.feature.parkify.features.parking.entities.Parking;
+import com.igrowker.feature.parkify.features.parking.repository.ParkingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ParkingServiceImpl - updateMyParkingAvailability Unit Tests")
+class ParkingServiceUpdateAvailabilityTest {
+
+    private static final String OWNER_EMAIL_EXISTS = "owner.exists@test.com";
+    private static final String OWNER_EMAIL_NOT_FOUND = "owner.notfound@test.com";
+    private static final Long OWNER_ID = 1L;
+    private static final Long PARKING_ID = 10L;
+    private static final int PARKING_CAPACITY = 20;
+    private static final int INITIAL_AVAILABLE_SPOTS = 10;
+    private static final int VALID_NEW_AVAILABLE_SPOTS = 15;
+    private static final int SPOTS_EXCEEDING_CAPACITY = 25;
+
+    @Mock
+    private ParkingRepository parkingRepository;
+    @Mock
+    private AuthUserRepository authUserRepository;
+    @InjectMocks
+    private ParkingServiceImpl parkingService;
+    @Captor
+    private ArgumentCaptor<Parking> parkingCaptor;
+    private AuthUser testOwner;
+    private Parking testParking;
+
+    @BeforeEach
+    void setUp() {
+        testOwner = new AuthUser();
+        testOwner.setId(OWNER_ID);
+        testOwner.setEmail(OWNER_EMAIL_EXISTS);
+        testParking = Parking.builder()
+                .id(PARKING_ID)
+                .ownerId(OWNER_ID)
+                .capacity(PARKING_CAPACITY)
+                .availableSpots(INITIAL_AVAILABLE_SPOTS)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Success Scenarios")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("Should update available spots and return correct response when owner and parking exist")
+        void updateMyParkingAvailability_OwnerAndParkingExist_ShouldUpdateAndReturnResponse() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findByOwnerId(OWNER_ID)).thenReturn(List.of(testParking));
+            when(parkingRepository.save(any(Parking.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            final ParkingAvailabilityResponse response = parkingService.updateMyParkingAvailability(
+                    OWNER_EMAIL_EXISTS, VALID_NEW_AVAILABLE_SPOTS
+            );
+
+            verify(parkingRepository, times(1)).save(parkingCaptor.capture());
+            final Parking savedParking = parkingCaptor.getValue();
+
+            assertThat(savedParking.getAvailableSpots())
+                    .as("Check saved available spots")
+                    .isEqualTo(VALID_NEW_AVAILABLE_SPOTS);
+            assertThat(savedParking.getCapacity())
+                    .as("Check capacity remains unchanged")
+                    .isEqualTo(PARKING_CAPACITY);
+            assertThat(response).isNotNull();
+            assertThat(response.parkingId())
+                    .as("Check response parking ID")
+                    .isEqualTo(PARKING_ID);
+            assertThat(response.availableSpots())
+                    .as("Check response available spots")
+                    .isEqualTo(VALID_NEW_AVAILABLE_SPOTS);
+            verify(authUserRepository, times(1)).findByEmail(OWNER_EMAIL_EXISTS);
+            verify(parkingRepository, times(1)).findByOwnerId(OWNER_ID);
+            verifyNoMoreInteractions(authUserRepository, parkingRepository);
+        }
+
+        @Test
+        @DisplayName("Should allow updating spots to zero")
+        void updateMyParkingAvailability_UpdateToZero_ShouldSucceed() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findByOwnerId(OWNER_ID)).thenReturn(List.of(testParking));
+            when(parkingRepository.save(any(Parking.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            ParkingAvailabilityResponse response = parkingService.updateMyParkingAvailability(
+                    OWNER_EMAIL_EXISTS, 0
+            );
+
+            verify(parkingRepository).save(parkingCaptor.capture());
+            assertThat(parkingCaptor.getValue().getAvailableSpots()).isZero();
+            assertThat(response.availableSpots()).isZero();
+        }
+
+        @Test
+        @DisplayName("Should allow updating spots to full capacity")
+        void updateMyParkingAvailability_UpdateToCapacity_ShouldSucceed() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findByOwnerId(OWNER_ID)).thenReturn(List.of(testParking));
+            when(parkingRepository.save(any(Parking.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            ParkingAvailabilityResponse response = parkingService.updateMyParkingAvailability(
+                    OWNER_EMAIL_EXISTS, PARKING_CAPACITY
+            );
+
+            verify(parkingRepository).save(parkingCaptor.capture());
+            assertThat(parkingCaptor.getValue().getAvailableSpots()).isEqualTo(PARKING_CAPACITY);
+            assertThat(response.availableSpots()).isEqualTo(PARKING_CAPACITY);
+        }
+    }
+
+    @Nested
+    @DisplayName("Failure Scenarios")
+    class FailureTests {
+
+        @Test
+        @DisplayName("Should throw OwnerNotFoundException when owner email does not exist")
+        void updateMyParkingAvailability_OwnerNotFound_ShouldThrowOwnerNotFoundException() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_NOT_FOUND)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> parkingService.updateMyParkingAvailability(
+                    OWNER_EMAIL_NOT_FOUND, VALID_NEW_AVAILABLE_SPOTS))
+                    .isInstanceOf(OwnerNotFoundException.class)
+                    .hasMessageContaining("Authenticated owner not found with email: " + OWNER_EMAIL_NOT_FOUND);
+
+            verify(parkingRepository, never()).findByOwnerId(anyLong());
+            verify(parkingRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw ParkingNotFoundException when owner exists but has no parking")
+        void updateMyParkingAvailability_ParkingNotFound_ShouldThrowParkingNotFoundException() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findByOwnerId(OWNER_ID)).thenReturn(Collections.emptyList());
+
+            assertThatThrownBy(() -> parkingService.updateMyParkingAvailability(
+                    OWNER_EMAIL_EXISTS, VALID_NEW_AVAILABLE_SPOTS))
+                    .isInstanceOf(ParkingNotFoundException.class)
+                    .hasMessageContaining("Parking not found for owner with email: " + OWNER_EMAIL_EXISTS);
+
+            verify(parkingRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when available spots exceed capacity")
+        void updateMyParkingAvailability_SpotsExceedCapacity_ShouldThrowIllegalArgumentException() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findByOwnerId(OWNER_ID)).thenReturn(List.of(testParking));
+
+            assertThatThrownBy(() -> parkingService.updateMyParkingAvailability(
+                    OWNER_EMAIL_EXISTS, SPOTS_EXCEEDING_CAPACITY))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Available spots (%d) cannot exceed capacity (%d)",
+                            SPOTS_EXCEEDING_CAPACITY, PARKING_CAPACITY);
+
+            verify(parkingRepository, never()).save(any());
+        }
+
+    }
+}


### PR DESCRIPTION
Añade el endpoint `PATCH /api/v1/parkings/my/availability` para que los propietarios autenticados actualicen los puestos disponibles de su estacionamiento. Incluye la lógica del servicio, DTO (`UpdateAvailabilityRequest`) y pruebas unitarias. Marca el antiguo endpoint PUT como obsoleto.

**Motivación**

Proporcionar un método PATCH semánticamente correcto y seguro para la actualización parcial de la disponibilidad por parte del propietario.
===

Adds the `PATCH /api/v1/parkings/my/availability` endpoint for authenticated owners to update their parking's available spots. Includes service logic, DTO (`UpdateAvailabilityRequest`), and unit tests. Deprecates the old PUT endpoint.

**Motivation**

Provide a semantically correct and secure PATCH method for partial availability updates by the owner.