### PR TITLE
feat(parking): Add batch availability endpoint and deprecate nearby

### DIFF
--- a/src/main/java/com/igrowker/feature/parkify/features/auth/security/SecurityConfig.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/security/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
                                 antMatcher(HttpMethod.GET, PARKINGS_PATH),
                                 antMatcher(HttpMethod.GET, PARKINGS_PATH + "/{parkingId}"),
                                 antMatcher(HttpMethod.GET, PARKINGS_PATH + "/{parkingId}/availability"),
+                                antMatcher(HttpMethod.GET, PARKINGS_PATH + "/availability"),
                                 antMatcher(HttpMethod.GET, CONFIG_PATH + "/initial"),
                                 antMatcher(HttpMethod.GET, "/api/v1/features"),
                                 antMatcher(HttpMethod.GET, "/api/v1/features/**"),

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/controller/ParkingController.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/controller/ParkingController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -38,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -143,6 +145,40 @@ public class ParkingController {
     (@PathVariable Long parkingId
     ) {
         ParkingAvailabilityResponse response = parkingService.getParkingAvailability(parkingId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "Get Availability for Multiple Parkings (Batch)",
+            description = "Retrieves the current availability for a list of specified parking IDs. Publicly accessible."
+    )
+    @Parameter(
+            name = "ids",
+            required = true,
+            description = "Comma-separated list of parking IDs",
+            example = "1,5,23"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Availability data retrieved successfully",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    type = "array",
+                                    implementation = ParkingAvailabilityResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Invalid request (e.g., empty 'ids' parameter)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
+    })
+    @GetMapping("/availability")
+    public ResponseEntity<List<ParkingAvailabilityResponse>> getParkingsAvailability(
+            @RequestParam @NotEmpty(message = "Parameter 'ids' cannot be empty") List<Long> ids
+    ) {
+        final List<ParkingAvailabilityResponse> response = parkingService.getParkingsAvailability(ids);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingService.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingService.java
@@ -8,9 +8,12 @@ import com.igrowker.feature.parkify.features.parking.dto.response.PaginatedParki
 import com.igrowker.feature.parkify.features.parking.dto.response.ParkingAvailabilityResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.ParkingDetailsResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.ParkingResponse;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface ParkingService {
 
@@ -44,6 +47,18 @@ public interface ParkingService {
             @NotNull(message = "Available spots cannot be null")
             @PositiveOrZero(message = "Available spots must be zero or positive")
             Integer availableSpots
+    );
+
+    /**
+     * Retrieves the current availability for a list of parking facilities.
+     *
+     * @param parkingIds A list of parking IDs to query. Must not be empty.
+     * @return A list of DTOs containing availability information for the found parkings.
+     *         Parkings not found for the given IDs will be omitted from the result.
+     */
+    List<ParkingAvailabilityResponse> getParkingsAvailability(
+            @NotEmpty(message = "List of parking IDs cannot be empty")
+            List<Long> parkingIds
     );
 
     ParkingDetailsResponse getMyParkingDetails(String ownerEmail);

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 
@@ -231,6 +232,22 @@ public class ParkingServiceImpl implements ParkingService {
     ) {
         return null;
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ParkingAvailabilityResponse> getParkingsAvailability(
+            List<Long> parkingIds
+    ) {
+        final List<Parking> foundParkings = parkingRepository.findAllById(parkingIds);
+
+        return foundParkings.stream()
+                .map(parking -> new ParkingAvailabilityResponse(
+                        parking.getId(),
+                        ofNullable(parking.getAvailableSpots()).orElse(0)
+                ))
+                .toList();
+    }
+
 
     @Override
     @Transactional(readOnly = true)

--- a/src/test/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceGetParkingsAvailabilityTest.java
+++ b/src/test/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceGetParkingsAvailabilityTest.java
@@ -1,0 +1,134 @@
+package com.igrowker.feature.parkify.features.parking.service;
+
+import com.igrowker.feature.parkify.features.parking.dto.response.ParkingAvailabilityResponse;
+import com.igrowker.feature.parkify.features.parking.entities.Parking;
+import com.igrowker.feature.parkify.features.parking.repository.ParkingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ParkingServiceImpl - getParkingsAvailability Unit Tests")
+class ParkingServiceGetParkingsAvailabilityTest {
+
+    @Mock
+    private ParkingRepository parkingRepository;
+    @InjectMocks
+    private ParkingServiceImpl parkingService;
+    private Parking parking1;
+    private Parking parking2;
+    private Parking parking3NullSpots;
+
+    @BeforeEach
+    void setUp() {
+        parking1 = Parking.builder().id(1L).availableSpots(10).build();
+        parking2 = Parking.builder().id(2L).availableSpots(5).build();
+        parking3NullSpots = Parking.builder().id(3L).availableSpots(null).build();
+    }
+
+    @Test
+    @DisplayName("Should return availability for all requested existing IDs")
+    void getParkingsAvailability_AllIdsExist_ShouldReturnAll() {
+        final List<Long> requestedIds = List.of(1L, 2L);
+        final List<Parking> foundParkings = List.of(parking1, parking2);
+        when(parkingRepository.findAllById(requestedIds)).thenReturn(foundParkings);
+
+        final List<ParkingAvailabilityResponse> result = parkingService
+                .getParkingsAvailability(requestedIds);
+
+        assertThat(result)
+                .isNotNull()
+                .hasSize(2)
+                .containsExactlyInAnyOrder(
+                        new ParkingAvailabilityResponse(1L, 10),
+                        new ParkingAvailabilityResponse(2L, 5)
+                );
+
+        verify(parkingRepository, times(1)).findAllById(requestedIds);
+        verifyNoMoreInteractions(parkingRepository);
+    }
+
+    @Test
+    @DisplayName("Should return availability only for found IDs when some IDs do not exist")
+    void getParkingsAvailability_SomeIdsNotExist_ShouldReturnOnlyFound() {
+        final List<Long> requestedIds = List.of(1L, 99L, 2L);
+        final List<Parking> foundParkings = List.of(parking1, parking2);
+        when(parkingRepository.findAllById(requestedIds)).thenReturn(foundParkings);
+
+        final List<ParkingAvailabilityResponse> result = parkingService.getParkingsAvailability(requestedIds);
+
+        assertThat(result)
+                .isNotNull()
+                .hasSize(2)
+                .containsExactlyInAnyOrder(
+                        new ParkingAvailabilityResponse(1L, 10),
+                        new ParkingAvailabilityResponse(2L, 5)
+                );
+
+        verify(parkingRepository, times(1)).findAllById(requestedIds);
+        verifyNoMoreInteractions(parkingRepository);
+    }
+
+    @Test
+    @DisplayName("Should return empty list when no requested IDs exist")
+    void getParkingsAvailability_NoIdsExist_ShouldReturnEmptyList() {
+        final List<Long> requestedIds = List.of(98L, 99L);
+        when(parkingRepository.findAllById(requestedIds)).thenReturn(Collections.emptyList());
+
+        final List<ParkingAvailabilityResponse> result = parkingService.getParkingsAvailability(requestedIds);
+
+        assertThat(result)
+                .isNotNull()
+                .isEmpty();
+        verify(parkingRepository, times(1)).findAllById(requestedIds);
+        verifyNoMoreInteractions(parkingRepository);
+    }
+
+    @Test
+    @DisplayName("Should return 0 availability when availableSpots is null in the entity")
+    void getParkingsAvailability_NullAvailableSpots_ShouldReturnZero() {
+        final List<Long> requestedIds = java.util.List.of(1L, 3L);
+        final List<Parking> foundParkings = List.of(parking1, parking3NullSpots);
+        when(parkingRepository.findAllById(requestedIds)).thenReturn(foundParkings);
+
+        final List<ParkingAvailabilityResponse> result = parkingService.getParkingsAvailability(requestedIds);
+
+        assertThat(result)
+                .isNotNull()
+                .hasSize(2)
+                .containsExactlyInAnyOrder(
+                        new ParkingAvailabilityResponse(1L, 10),
+                        new ParkingAvailabilityResponse(3L, 0)
+                );
+        verify(parkingRepository, times(1)).findAllById(requestedIds);
+        verifyNoMoreInteractions(parkingRepository);
+    }
+
+    @Test
+    @DisplayName("Should return empty list when requested ID list is empty (handled by validation before service)")
+    void getParkingsAvailability_EmptyIdList_ShouldReturnEmptyList() {
+        final List<Long> requestedIds = Collections.emptyList();
+        when(parkingRepository.findAllById(requestedIds)).thenReturn(Collections.emptyList());
+
+        final List<ParkingAvailabilityResponse> result = parkingService.getParkingsAvailability(requestedIds);
+
+        assertThat(result)
+                .isNotNull()
+                .isEmpty();
+        verify(parkingRepository, times(1)).findAllById(requestedIds);
+        verifyNoMoreInteractions(parkingRepository);
+    }
+}


### PR DESCRIPTION
Añade el endpoint público `GET /api/v1/parkings/availability?ids=...` para obtener la disponibilidad de múltiples estacionamientos en una sola solicitud (optimización para polling del frontend).

**Cambios Principales**

*   Nuevo método `getParkingsAvailability` en `ParkingService` y su implementación.
*   Nuevo endpoint público en `ParkingController`.
*   Añadida regla `permitAll` en `SecurityConfig` para el nuevo endpoint.
*   Añadidas pruebas unitarias para el nuevo método del servicio.

___
Adds the public endpoint `GET /api/v1/parkings/availability?ids=...` to fetch availability for multiple parkings in a single request (optimization for frontend polling).

**Main Changes**

*   New `getParkingsAvailability` method in `ParkingService` and its implementation.
*   New public endpoint in `ParkingController`.
*   Added `permitAll` rule in `SecurityConfig` for the new endpoint.
*   Added unit tests for the new service method.