### PR TITLE
chore(user): Deprecate PUT /users/me/location endpoint

### DIFF
--- a/src/main/java/com/igrowker/feature/parkify/features/user/controller/UserController.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/user/controller/UserController.java
@@ -22,12 +22,17 @@ public class UserController {
     private final UserService userService;
 
     // #19
-    @Operation(summary = "Update current user's location")
+    @Operation(
+            summary = "Update current user's location (DEPRECATED)",
+            description = "DEPRECATED: This endpoint is no longer recommended for use in the primary driver flow. Location is typically passed as query parameters in parking search requests.",
+            deprecated = true
+    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Location updated successfully"),
             @ApiResponse(responseCode = "400", description = "Invalid request")
     })
     @PutMapping("/me/location")
+    @Deprecated(since = "2024-04-23", forRemoval = true)
     public ResponseEntity<Void> updateMyLocation(
             @Valid @RequestBody LocationUpdateRequest request, Authentication authentication
     ) {

--- a/src/main/java/com/igrowker/feature/parkify/features/user/service/UserService.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.igrowker.feature.parkify.features.user.dto.response.PublicUserRespons
 import jakarta.validation.Valid;
 
 public interface UserService {
+    @Deprecated(since = "2024-04-23", forRemoval = true)
     void updateUserLocation(String name, @Valid LocationUpdateRequest request);
 
     PublicUserResponse getPublicUserById(String userId);

--- a/src/main/java/com/igrowker/feature/parkify/features/user/service/UserServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/user/service/UserServiceImpl.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 public class UserServiceImpl implements UserService {
     private final AuthUserRepository authUserRepository;
     @Override
+    @Deprecated(since = "2024-04-23", forRemoval = true)
     public void updateUserLocation(String email, LocationUpdateRequest request) {
         log.info("Updating location for user: {}", email);
         AuthUser user = authUserRepository.findByEmail(email)


### PR DESCRIPTION
Marca como obsoleto (`@Deprecated`) el endpoint `PUT /api/v1/users/me/location` y sus métodos de servicio correspondientes.

**Motivación**

Alinear la API con la decisión de no almacenar la ubicación del conductor en el backend para el MVP. La ubicación ahora se espera como parámetro de consulta en la búsqueda de estacionamientos (`GET /parkings`). Las pruebas relacionadas han sido deshabilitadas.
___

Marks the `PUT /api/v1/users/me/location` endpoint and corresponding service methods as deprecated (`@Deprecated`).

**Motivation**

Align the API with the decision to not store driver location on the backend for the MVP. Location is now expected as a query parameter in parking search requests (`GET /parkings`). Related tests have been disabled.