### PR TITLE
Feat/fix put endpoint ownership

### DIFF
--- a/api-test/test_api.sh
+++ b/api-test/test_api.sh
@@ -246,6 +246,203 @@ curl -v -X PATCH "$BASE_URL/parkings/${PARKING_ID_1}/availability" \
      -o response.body 2> curl_output.log
 check_status curl_output.log 400 "Actualización de disponibilidad P1 (> capacidad)"
 
+# === Preparación para Prueba de Seguridad PUT: Crear Segundo Propietario y su Parking ===
+
+section_header "2.prep Preparación: Segundo Propietario y Parking"
+
+# --- Variables para el Segundo Propietario ---
+OWNER_EMAIL_2="curl_owner2_$(date +%s%N)@example.com"
+OWNER_PASSWORD_2="password456"
+TOKEN_2=""
+PARKING_ID_OWNER_2=""
+
+echo "[INFO] Registrando segundo propietario: $OWNER_EMAIL_2"
+rm -f response.body curl_output.log
+curl -v -X POST "$BASE_URL/auth/register" \
+     -H "Content-Type: application/json" \
+     -d "{\"email\": \"$OWNER_EMAIL_2\", \"password\": \"$OWNER_PASSWORD_2\", \"username\": \"Curl Test Owner 2\", \"role\": \"OWNER\", \"contactPhone\": \"999999999\"}" \
+     -o response.body 2> curl_output.log
+check_status curl_output.log 201 "Registro del Segundo Propietario"
+
+echo "[INFO] Iniciando sesión como segundo propietario: $OWNER_EMAIL_2"
+RESPONSE_BODY_2=$(curl -s -X POST "$BASE_URL/auth/login" \
+     -H "Content-Type: application/json" \
+     -d "{\"email\": \"$OWNER_EMAIL_2\", \"password\": \"$OWNER_PASSWORD_2\"}")
+TOKEN_2=$(echo $RESPONSE_BODY_2 | jq -r '.token // empty')
+
+if [ -z "$TOKEN_2" ] || [ "$TOKEN_2" == "null" ]; then
+    echo "[ERROR] No se pudo obtener el token para el Propietario 2. Saltando creación de su parking."
+else
+    echo "[OK] Token obtenido para Propietario 2."
+    echo "[INFO] Creando parking para el Propietario 2 (usando TOKEN_2)"
+    PARKING_DATA_OWNER_2=$(cat <<EOF
+{
+    "name": "Parking del Propietario 2",
+    "address": "2 Otra Calle",
+    "latitude": 41.0,
+    "longitude": -4.0,
+    "description": "Parking perteneciente al segundo propietario",
+    "capacity": 5,
+    "hourlyRate": 3.0,
+    "workingHours": "09:00-19:00",
+    "parkingPhone": "888888",
+    "parkingImageUrl": "http://example.com/owner2_parking.jpg"
+}
+EOF
+)
+    CREATE_RESPONSE_OWNER_2=$(echo "$PARKING_DATA_OWNER_2" | curl -s -X POST "$BASE_URL/parkings/my" \
+         -H "Authorization: Bearer $TOKEN_2" \
+         -H "Content-Type: application/json" \
+         -d @-)
+    PARKING_ID_OWNER_2=$(echo $CREATE_RESPONSE_OWNER_2 | jq -r '.id // empty')
+
+    if [ -z "$PARKING_ID_OWNER_2" ] || [ "$PARKING_ID_OWNER_2" == "null" ]; then
+        echo "[ERROR] No se pudo crear el parking para el Propietario 2."
+    else
+        echo "[OK] Parking para Propietario 2 creado, ID: $PARKING_ID_OWNER_2"
+    fi
+fi
+
+# --- Fin de la preparación ---
+
+# === Flujo del Propietario: Actualización PUT de Parking Específico (por ID) ===
+
+section_header "2.bis Flujo de Actualización PUT del Parking Específico (por ID)"
+
+# --- Pre-requisitos: Necesitamos TOKEN (Propietario 1) y PARKING_ID_1 ---
+if [ -z "$TOKEN" ] || [ "$TOKEN" == "null" ] || [ -z "$PARKING_ID_1" ] || [ "$PARKING_ID_1" == "null" ]; then
+    echo "[OMITIDO] Saltando pruebas PUT por ID: Falta TOKEN (Propietario 1) o PARKING_ID_1."
+else
+    echo "[INFO] Usando TOKEN (Propietario 1) y PARKING_ID: $PARKING_ID_1 para pruebas PUT por ID."
+
+    # --- Datos para la actualización PUT (para PARKING_ID_1) ---
+    UPDATE_DATA=$(cat <<EOF
+{
+    "name": "Parking 1 Actualizado Curl",
+    "address": "1 Calle Curl Actualizada",
+    "latitude": ${SEARCH_LAT},
+    "longitude": ${SEARCH_LON},
+    "description": "Descripción Actualizada vía PUT",
+    "capacity": 18,
+    "hourlyRate": 5.0,
+    "workingHours": "08:00-20:00 Actualizado",
+    "parkingPhone": "111-ACTUALIZADO",
+    "parkingImageUrl": "http://example.com/image1_actualizada.jpg"
+}
+EOF
+)
+    echo "[INFO] Datos para la actualización PUT exitosa (ID: $PARKING_ID_1):"
+    echo "$UPDATE_DATA" | jq '.'
+
+    INVALID_CAP_DATA=$(cat <<EOF
+{
+    "name": "Parking Capacidad Inválida",
+    "address": "Calle Cap Inválida",
+    "latitude": ${SEARCH_LAT},
+    "longitude": ${SEARCH_LON},
+    "description": "Probando capacidad inválida",
+    "capacity": 5,
+    "hourlyRate": 5.5,
+    "workingHours": "09:00-17:00",
+    "parkingPhone": "cap-invalida",
+    "parkingImageUrl": "http://example.com/cap_invalida.jpg"
+}
+EOF
+)
+    echo "[INFO] Datos para la actualización con capacity inválida (< plazas disponibles) (ID: $PARKING_ID_1):"
+    echo "$INVALID_CAP_DATA" | jq '.'
+
+
+    # --- Inicio de las pruebas PUT /{parkingId} ---
+    echo -e "\n[2.bis.1 Negativo: Actualización PUT /{parkingId} sin Token (Esperado 403)]"
+    rm -f response.body curl_output.log
+    echo "$UPDATE_DATA" | curl -v -X PUT "$BASE_URL/parkings/$PARKING_ID_1" \
+         -H "Content-Type: application/json" \
+         -d @- \
+         -o response.body 2> curl_output.log
+    check_status curl_output.log 403 "Actualización PUT /{parkingId} sin token"
+
+    echo -e "\n[2.bis.2 Negativo: Actualización PUT /{parkingId} con Token Inválido (Esperado 403)]"
+    rm -f response.body curl_output.log
+    echo "$UPDATE_DATA" | curl -v -X PUT "$BASE_URL/parkings/$PARKING_ID_1" \
+         -H "Authorization: Bearer $INVALID_TOKEN" \
+         -H "Content-Type: application/json" \
+         -d @- \
+         -o response.body 2> curl_output.log
+    check_status curl_output.log 403 "Actualización PUT /{parkingId} con token inválido"
+
+    echo -e "\n[2.bis.3 Negativo: Actualización PUT /{parkingId} con Campo Obligatorio Faltante (name) (Esperado 400)]"
+    MISSING_NAME_DATA=$(echo "$UPDATE_DATA" | jq 'del(.name)')
+    echo "[INFO] Datos para la actualización sin el campo 'name' (ID: $PARKING_ID_1):"
+    echo "$MISSING_NAME_DATA" | jq '.'
+    rm -f response.body curl_output.log
+    echo "$MISSING_NAME_DATA" | curl -v -X PUT "$BASE_URL/parkings/$PARKING_ID_1" \
+         -H "Authorization: Bearer $TOKEN" \
+         -H "Content-Type: application/json" \
+         -d @- \
+         -o response.body 2> curl_output.log
+    check_status curl_output.log 400 "Actualización PUT /{parkingId} sin campo 'name'"
+    echo "Cuerpo de la respuesta (error de validación):"
+    cat response.body | jq '.details // .message // empty' || cat response.body
+
+    echo -e "\n[2.bis.4 Negativo: Actualización PUT /{parkingId} con Capacity < Plazas Disponibles (Esperado 400)]"
+    rm -f response.body curl_output.log
+    echo "$INVALID_CAP_DATA" | curl -v -X PUT "$BASE_URL/parkings/$PARKING_ID_1" \
+         -H "Authorization: Bearer $TOKEN" \
+         -H "Content-Type: application/json" \
+         -d @- \
+         -o response.body 2> curl_output.log
+    check_status curl_output.log 400 "Actualización PUT /{parkingId} con capacity < available"
+    echo "Cuerpo de la respuesta (error de capacity):"
+    cat response.body | jq '.message // empty' || cat response.body
+
+    echo -e "\n[2.bis.4.1 Negativo: Actualización PUT /{parkingId} de parking ajeno (Esperado 403)]"
+    # Intentamos actualizar el parking del Propietario 2 (PARKING_ID_OWNER_2) usando el token del Propietario 1 (TOKEN)
+    if [ ! -z "$PARKING_ID_OWNER_2" ] && [ "$PARKING_ID_OWNER_2" != "null" ]; then
+        rm -f response.body curl_output.log
+        echo "[INFO] Intentando actualizar parking ID $PARKING_ID_OWNER_2 (de Owner 2) con token de Owner 1."
+        # Usamos los datos válidos, el problema debe ser la autorización, no los datos
+        echo "$UPDATE_DATA" | curl -v -X PUT "$BASE_URL/parkings/$PARKING_ID_OWNER_2" \
+             -H "Authorization: Bearer $TOKEN" \
+             -H "Content-Type: application/json" \
+             -d @- \
+             -o response.body 2> curl_output.log
+        check_status curl_output.log 403 "Actualización PUT /{parkingId} de parking ajeno" # Esperamos 403 Forbidden
+    else
+        echo "[OMITIDO] No se pudo probar actualización de parking ajeno: Falta PARKING_ID_OWNER_2."
+    fi
+
+    echo -e "\n[2.bis.5 Positivo: Actualización PUT Exitosa del Parking Propio (ID: $PARKING_ID_1) (Esperado 200)]"
+    rm -f response.body curl_output.log
+    echo "$UPDATE_DATA" | curl -v -X PUT "$BASE_URL/parkings/$PARKING_ID_1" \
+         -H "Authorization: Bearer $TOKEN" \
+         -H "Content-Type: application/json" \
+         -d @- \
+         -o response.body 2> curl_output.log
+    check_status curl_output.log 200 "Actualización PUT exitosa para ID $PARKING_ID_1"
+    echo "[INFO] Cuerpo de la respuesta después del PUT exitoso:"
+    SUCCESSFUL_PUT_RESPONSE=$(cat response.body)
+    echo "$SUCCESSFUL_PUT_RESPONSE" | jq '.'
+
+    echo -e "\n[2.bis.6 Positivo: Verificación de Datos Actualizados vía GET /{parkingId}]"
+    rm -f response.body curl_output.log
+    curl -s -X GET "$BASE_URL/parkings/$PARKING_ID_1" \
+         -o response.body 2> curl_output.log
+
+    echo "[INFO] Datos del parking $PARKING_ID_1 después de la actualización (obtenidos vía GET /{parkingId}):"
+    UPDATED_PARKING_DETAILS=$(cat response.body)
+    echo "$UPDATED_PARKING_DETAILS" | jq '.'
+
+    # Verificación del nombre
+    UPDATED_NAME=$(echo "$UPDATED_PARKING_DETAILS" | jq -r '.name // empty')
+    EXPECTED_NAME="Parking 1 Actualizado Curl"
+    if [ "$UPDATED_NAME" == "$EXPECTED_NAME" ]; then
+        echo "[OK] Verificación del nombre después de la actualización: El nombre '$UPDATED_NAME' coincide con el esperado."
+    else
+        echo "[ERROR] Verificación del nombre después de la actualización: Se esperaba '$EXPECTED_NAME', se recibió '$UPDATED_NAME'."
+    fi
+
+fi # Fin del bloque de verificación de TOKEN y PARKING_ID_1
 
 # === Pruebas de Peticiones de Disponibilidad Múltiple (Batch) (con Pruebas Negativas) ===
 section_header "3. Pruebas de Peticiones de Disponibilidad Múltiple (Batch)"

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/security/SecurityConfig.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                                 antMatcher(HttpMethod.POST, PARKINGS_PATH + "/my"),
                                 antMatcher(HttpMethod.GET, PARKINGS_PATH + "/my"),
                                 antMatcher(HttpMethod.GET, PARKINGS_PATH + "/my"),
+                                antMatcher(HttpMethod.PUT, PARKINGS_PATH + "/{parkingId}"),
                                 antMatcher(HttpMethod.GET, PARKINGS_PATH + "/my-list"),
                                 antMatcher(HttpMethod.DELETE, PARKINGS_PATH + "/my"),
                                 antMatcher(HttpMethod.PATCH, PARKINGS_PATH + "/my/availability"),

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/controller/ParkingController.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/controller/ParkingController.java
@@ -439,28 +439,58 @@ public class ParkingController {
     }
 
     @Operation(
-            summary = "Update Specific Parking (PUT)", // Изменили summary
-            description = "Allows an authenticated OWNER to completely update the editable details of a specific parking facility identified by its ID. Requires sending ALL editable fields." // Изменили описание
+            summary = "Update Specific Parking (PUT)",
+            description = "Allows an authenticated OWNER to completely update the editable " +
+                    "details of a specific parking facility identified by its ID. Requires " +
+                    "sending ALL editable fields."
     )
-    @Parameter(name = "parkingId", description = "ID of the parking to update", required = true, in = ParameterIn.PATH)
-    // Добавили параметр пути
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "Complete updated details for the parking", required = true,
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+    @Parameter
+            (name = "parkingId",
+            description = "ID of the parking to update",
+            required = true, in = ParameterIn.PATH
+            )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Complete updated details for the parking", required = true,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
                     schema = @Schema(implementation = UpdateMyParkingRequest.class)))
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Parking updated successfully",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Parking updated successfully",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = ParkingResponse.class))),
-            @ApiResponse(responseCode = "400", description = "Invalid request data (validation error, e.g., capacity conflict)",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
-            @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Forbidden (Not an OWNER or not the owner of this parking)", // Уточнили 403
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "Owner or Parking not found", // Уточнили 404
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request data (validation error, e.g., capacity conflict)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = GlobalExceptionHandler.ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Forbidden (Not an OWNER or not the owner of this parking)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = GlobalExceptionHandler.ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Owner or Parking not found",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = GlobalExceptionHandler.ErrorResponse.class)
+                    )
+            )
     })
     @PutMapping("/{parkingId}")
     public ResponseEntity<ParkingResponse> updateSpecificParking(

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/controller/ParkingController.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/controller/ParkingController.java
@@ -4,6 +4,7 @@ import com.igrowker.feature.parkify.exception.GlobalExceptionHandler;
 import com.igrowker.feature.parkify.features.parking.dto.request.CreateMyParkingRequest;
 import com.igrowker.feature.parkify.features.parking.dto.request.ParkingRequest;
 import com.igrowker.feature.parkify.features.parking.dto.request.UpdateAvailabilityRequest;
+import com.igrowker.feature.parkify.features.parking.dto.request.UpdateMyParkingRequest;
 import com.igrowker.feature.parkify.features.parking.dto.response.OwnerParkingDetailsResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.PaginatedParkingResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.ParkingAvailabilityResponse;
@@ -435,6 +436,41 @@ public class ParkingController {
                 ownerEmail, parkingId, request.availableSpots()
         );
         return ResponseEntity.ok(updatedAvailability);
+    }
+
+    @Operation(
+            summary = "Update Specific Parking (PUT)", // Изменили summary
+            description = "Allows an authenticated OWNER to completely update the editable details of a specific parking facility identified by its ID. Requires sending ALL editable fields." // Изменили описание
+    )
+    @Parameter(name = "parkingId", description = "ID of the parking to update", required = true, in = ParameterIn.PATH)
+    // Добавили параметр пути
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "Complete updated details for the parking", required = true,
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = UpdateMyParkingRequest.class)))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Parking updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ParkingResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request data (validation error, e.g., capacity conflict)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden (Not an OWNER or not the owner of this parking)", // Уточнили 403
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Owner or Parking not found", // Уточнили 404
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
+    })
+    @PutMapping("/{parkingId}")
+    public ResponseEntity<ParkingResponse> updateSpecificParking(
+            @PathVariable Long parkingId,
+            @Valid @RequestBody UpdateMyParkingRequest request,
+            Authentication authentication
+    ) {
+        final String ownerEmail = authentication.getName();
+        final ParkingResponse updatedParking = parkingService.updateMyParking(ownerEmail, parkingId, request);
+        return ResponseEntity.ok(updatedParking);
     }
 
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/dto/request/UpdateMyParkingRequest.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/dto/request/UpdateMyParkingRequest.java
@@ -1,0 +1,68 @@
+package com.igrowker.feature.parkify.features.parking.dto.request;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+/**
+ * DTO for updating an owner's parking details using PUT.
+ * Represents the complete set of editable fields for a parking.
+ * availableSpots is updated via a separate PATCH endpoint.
+ *
+ * @param name            Parking name (required, max 255 chars).
+ * @param address         Parking address (required, max 500 chars).
+ * @param latitude        Latitude (required, -90 to 90).
+ * @param longitude       Longitude (required, -180 to 180).
+ * @param description     Optional description (max 1000 chars).
+ * @param capacity        Total parking capacity (required, non-negative). Validation against available spots happens in service layer.
+ * @param hourlyRate      Hourly rate (required, non-negative).
+ * @param workingHours    Optional working hours description (max 255 chars).
+ * @param parkingPhone    Optional contact phone for the parking (max 20 chars).
+ * @param parkingImageUrl Optional URL for the parking image (max 2048 chars).
+ */
+@Builder
+public record UpdateMyParkingRequest(
+
+        @NotBlank(message = "Parking name cannot be blank")
+        @Size(max = 255, message = "Name cannot exceed 255 characters")
+        String name,
+
+        @NotBlank(message = "Parking address cannot be blank")
+        @Size(max = 500, message = "Address cannot exceed 500 characters")
+        String address,
+
+        @NotNull(message = "Latitude cannot be null")
+        @DecimalMin(value = "-90.0", message = "Latitude must be >= -90")
+        @DecimalMax(value = "90.0", message = "Latitude must be <= 90")
+        Double latitude,
+
+        @NotNull(message = "Longitude cannot be null")
+        @DecimalMin(value = "-180.0", message = "Longitude must be >= -180")
+        @DecimalMax(value = "180.0", message = "Longitude must be <= 180")
+        Double longitude,
+
+        @Size(max = 1000, message = "Description cannot exceed 1000 characters")
+        String description,
+
+        @NotNull(message = "Capacity cannot be null")
+        @PositiveOrZero(message = "Capacity must be zero or positive")
+        Integer capacity,
+
+        @NotNull(message = "Hourly rate cannot be null")
+        @PositiveOrZero(message = "Hourly rate must be zero or positive")
+        Double hourlyRate,
+
+        @Size(max = 255, message = "Working hours cannot exceed 255 characters")
+        String workingHours,
+
+        @Size(max = 20, message = "Phone number cannot exceed 20 characters")
+        String parkingPhone,
+
+        @Size(max = 2048, message = "Image URL cannot exceed 2048 characters")
+        String parkingImageUrl
+) {
+}

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingService.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingService.java
@@ -4,16 +4,19 @@ import com.igrowker.feature.parkify.exception.OwnerNotFoundException;
 import com.igrowker.feature.parkify.exception.ParkingNotFoundException;
 import com.igrowker.feature.parkify.features.parking.dto.request.CreateMyParkingRequest;
 import com.igrowker.feature.parkify.features.parking.dto.request.ParkingRequest;
+import com.igrowker.feature.parkify.features.parking.dto.request.UpdateMyParkingRequest;
 import com.igrowker.feature.parkify.features.parking.dto.response.OwnerParkingDetailsResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.PaginatedParkingResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.ParkingAvailabilityResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.ParkingDetailsResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.ParkingResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.ParkingSummaryResponse;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.util.List;
 
@@ -48,10 +51,10 @@ public interface ParkingService {
     /**
      * Updates the available spots for the parking associated with the given owner.
      *
-     * @param ownerEmail The email of the authenticated owner.
+     * @param ownerEmail     The email of the authenticated owner.
      * @param availableSpots The new number of available spots. Must be not null and non-negative.
      * @return A DTO containing the updated availability information.
-     * @throws OwnerNotFoundException if the owner is not found.
+     * @throws OwnerNotFoundException   if the owner is not found.
      * @throws ParkingNotFoundException if the owner has no associated parking.
      * @throws IllegalArgumentException if availableSpots is negative or exceeds capacity (optional check).
      */
@@ -67,7 +70,7 @@ public interface ParkingService {
      * Assumes an owner has at most one parking for simplicity in MVP.
      *
      * @param ownerEmail The email of the authenticated owner.
-     * @throws OwnerNotFoundException if the owner is not found.
+     * @throws OwnerNotFoundException   if the owner is not found.
      * @throws ParkingNotFoundException if the owner has no associated parking to delete.
      */
     void deleteMyParking(String ownerEmail);
@@ -77,7 +80,7 @@ public interface ParkingService {
      *
      * @param parkingIds A list of parking IDs to query. Must not be empty.
      * @return A list of DTOs containing availability information for the found parkings.
-     *         Parkings not found for the given IDs will be omitted from the result.
+     * Parkings not found for the given IDs will be omitted from the result.
      */
     List<ParkingAvailabilityResponse> getParkingsAvailability(
             @NotEmpty(message = "List of parking IDs cannot be empty")
@@ -102,6 +105,20 @@ public interface ParkingService {
             @PositiveOrZero(message = "Available spots must be zero or positive")
             Integer integer
     );
+
+    /**
+     * Updates the details of a specific parking facility owned by the authenticated user.
+     *
+     * @param ownerEmail The email of the authenticated owner.
+     * @param parkingId  The ID of the parking to update.
+     * @param request    The DTO containing the updated parking details.
+     * @return A DTO representing the updated parking.
+     * @throws OwnerNotFoundException   if the owner is not found.
+     * @throws ParkingNotFoundException if the parking with the given ID is not found.
+     * @throws AccessDeniedException    if the authenticated user is not the owner of the parking.
+     * @throws IllegalArgumentException if validation fails (e.g., capacity < available spots).
+     */
+    ParkingResponse updateMyParking(String ownerEmail, Long parkingId, @Valid UpdateMyParkingRequest request);
 }
 
 

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceImpl.java
@@ -466,33 +466,20 @@ public class ParkingServiceImpl implements ParkingService {
 
     @Override
     @Transactional
-    public ParkingResponse updateMyParking(String ownerEmail, Long parkingId, @Valid UpdateMyParkingRequest request) {
+    public ParkingResponse updateMyParking(
+            String ownerEmail, Long parkingId, @Valid UpdateMyParkingRequest request
+    ) {
         log.info("Attempting to update parking ID {} for owner {}", parkingId, ownerEmail);
-
-        // 1. Найти владельца
         final AuthUser owner = findOwnerByEmail(ownerEmail);
-
-        // 2. Найти парковку по ID
         final Parking parking = findParkingById(parkingId);
-
-        // 3. Проверить владение
         ensureOwnership(owner, parking, ownerEmail);
-
-        // 4. Обновить поля парковки (кроме capacity и availableSpots пока)
         updateParkingFields(parking, request);
-
-        // 5. Обработать изменение Capacity с валидацией
         updateCapacityIfNeeded(parking, request.capacity());
-
-        // 6. Сохранить
         final Parking updatedParking = parkingRepository.save(parking);
         log.info("Parking {} successfully updated by owner {}", updatedParking.getId(), ownerEmail);
 
-        // 7. Смапить в DTO ответа и вернуть
         return mapToFlatParkingResponse(updatedParking, owner);
     }
-
-    // --- Вспомогательные приватные методы для улучшения читаемости updateMyParking ---
 
     private AuthUser findOwnerByEmail(String ownerEmail) {
         return authUserRepository.findByEmail(ownerEmail)
@@ -512,10 +499,13 @@ public class ParkingServiceImpl implements ParkingService {
 
     private void ensureOwnership(AuthUser owner, Parking parking, String ownerEmailForLogging) {
         if (!parking.getOwnerId().equals(owner.getId())) {
-            log.warn("Access denied: Owner {} (ID {}) attempted to modify parking {} which belongs to owner ID {}",
-                    ownerEmailForLogging, owner.getId(), parking.getId(), parking.getOwnerId());
+            log.warn("Access denied: Owner {} (ID {}) attempted to modify parking " +
+                            "{} which belongs to owner ID {}",
+                    ownerEmailForLogging, owner.getId(), parking.getId(), parking.getOwnerId()
+            );
             throw new AccessDeniedException(String.format(
-                    "User %s is not authorized to modify parking with id %d", ownerEmailForLogging, parking.getId()
+                    "User %s is not authorized to modify parking with id %d",
+                    ownerEmailForLogging, parking.getId()
             ));
         }
     }
@@ -533,23 +523,27 @@ public class ParkingServiceImpl implements ParkingService {
     }
 
     private void updateCapacityIfNeeded(Parking parking, Integer newCapacity) {
-        // Проверяем, только если capacity действительно изменилась
         if (!parking.getCapacity().equals(newCapacity)) {
             Integer currentAvailable = Optional.ofNullable(parking.getAvailableSpots())
-                    .orElse(parking.getCapacity()); // Используем capacity, если available null
+                    .orElse(parking.getCapacity());
 
             if (currentAvailable > newCapacity) {
-                log.warn("Capacity update failed for parking {}: requested capacity {} < current available {}",
+                log.warn("Capacity update failed for parking {}: requested capacity {} " +
+                                "< current available {}",
                         parking.getId(), newCapacity, currentAvailable);
                 throw new IllegalArgumentException(
-                        String.format("Cannot set capacity (%d) lower than current available spots (%d). Please update available spots first.",
+                        String.format("Cannot set capacity (%d) lower than current available " +
+                                        "spots (%d). Please update available spots first.",
                                 newCapacity, currentAvailable)
                 );
             }
             parking.setCapacity(newCapacity);
             log.debug("Parking {} capacity updated to {}", parking.getId(), newCapacity);
         } else {
-            log.debug("Capacity for parking {} not changed (remains {}). Skipping validation.", parking.getId(), newCapacity);
+            log.debug(
+                    "Capacity for parking {} not changed (remains {}). Skipping validation.",
+                    parking.getId(), newCapacity
+            );
         }
     }
 

--- a/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceImpl.java
@@ -8,6 +8,7 @@ import com.igrowker.feature.parkify.features.auth.repository.AuthUserRepository;
 import com.igrowker.feature.parkify.features.parking.dto.LocationDto;
 import com.igrowker.feature.parkify.features.parking.dto.request.CreateMyParkingRequest;
 import com.igrowker.feature.parkify.features.parking.dto.request.ParkingRequest;
+import com.igrowker.feature.parkify.features.parking.dto.request.UpdateMyParkingRequest;
 import com.igrowker.feature.parkify.features.parking.dto.response.OwnerParkingDetailsResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.PaginatedParkingResponse;
 import com.igrowker.feature.parkify.features.parking.dto.response.PaginationInfo;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
@@ -460,6 +462,95 @@ public class ParkingServiceImpl implements ParkingService {
 
         log.info("Successfully updated availability for parking {}", parkingId);
         return new ParkingAvailabilityResponse(parking.getId(), parking.getAvailableSpots());
+    }
+
+    @Override
+    @Transactional
+    public ParkingResponse updateMyParking(String ownerEmail, Long parkingId, @Valid UpdateMyParkingRequest request) {
+        log.info("Attempting to update parking ID {} for owner {}", parkingId, ownerEmail);
+
+        // 1. Найти владельца
+        final AuthUser owner = findOwnerByEmail(ownerEmail);
+
+        // 2. Найти парковку по ID
+        final Parking parking = findParkingById(parkingId);
+
+        // 3. Проверить владение
+        ensureOwnership(owner, parking, ownerEmail);
+
+        // 4. Обновить поля парковки (кроме capacity и availableSpots пока)
+        updateParkingFields(parking, request);
+
+        // 5. Обработать изменение Capacity с валидацией
+        updateCapacityIfNeeded(parking, request.capacity());
+
+        // 6. Сохранить
+        final Parking updatedParking = parkingRepository.save(parking);
+        log.info("Parking {} successfully updated by owner {}", updatedParking.getId(), ownerEmail);
+
+        // 7. Смапить в DTO ответа и вернуть
+        return mapToFlatParkingResponse(updatedParking, owner);
+    }
+
+    // --- Вспомогательные приватные методы для улучшения читаемости updateMyParking ---
+
+    private AuthUser findOwnerByEmail(String ownerEmail) {
+        return authUserRepository.findByEmail(ownerEmail)
+                .orElseThrow(() -> {
+                    log.warn("Owner not found: {}", ownerEmail);
+                    return new OwnerNotFoundException(AUTHENTICATED_OWNER_NOT_FOUND_WITH_EMAIL + ownerEmail);
+                });
+    }
+
+    private Parking findParkingById(Long parkingId) {
+        return parkingRepository.findById(parkingId)
+                .orElseThrow(() -> {
+                    log.warn("Parking not found with ID: {}", parkingId);
+                    return new ParkingNotFoundException("Parking not found with id: " + parkingId);
+                });
+    }
+
+    private void ensureOwnership(AuthUser owner, Parking parking, String ownerEmailForLogging) {
+        if (!parking.getOwnerId().equals(owner.getId())) {
+            log.warn("Access denied: Owner {} (ID {}) attempted to modify parking {} which belongs to owner ID {}",
+                    ownerEmailForLogging, owner.getId(), parking.getId(), parking.getOwnerId());
+            throw new AccessDeniedException(String.format(
+                    "User %s is not authorized to modify parking with id %d", ownerEmailForLogging, parking.getId()
+            ));
+        }
+    }
+
+    private void updateParkingFields(Parking parking, UpdateMyParkingRequest request) {
+        parking.setName(request.name());
+        parking.setAddress(request.address());
+        parking.setLatitude(request.latitude());
+        parking.setLongitude(request.longitude());
+        parking.setDescription(request.description());
+        parking.setHourlyRate(request.hourlyRate());
+        parking.setWorkingHours(request.workingHours());
+        parking.setParkingPhone(request.parkingPhone());
+        parking.setParkingImageUrl(request.parkingImageUrl());
+    }
+
+    private void updateCapacityIfNeeded(Parking parking, Integer newCapacity) {
+        // Проверяем, только если capacity действительно изменилась
+        if (!parking.getCapacity().equals(newCapacity)) {
+            Integer currentAvailable = Optional.ofNullable(parking.getAvailableSpots())
+                    .orElse(parking.getCapacity()); // Используем capacity, если available null
+
+            if (currentAvailable > newCapacity) {
+                log.warn("Capacity update failed for parking {}: requested capacity {} < current available {}",
+                        parking.getId(), newCapacity, currentAvailable);
+                throw new IllegalArgumentException(
+                        String.format("Cannot set capacity (%d) lower than current available spots (%d). Please update available spots first.",
+                                newCapacity, currentAvailable)
+                );
+            }
+            parking.setCapacity(newCapacity);
+            log.debug("Parking {} capacity updated to {}", parking.getId(), newCapacity);
+        } else {
+            log.debug("Capacity for parking {} not changed (remains {}). Skipping validation.", parking.getId(), newCapacity);
+        }
     }
 
     private record ParkingWithDistance(Parking parking, double distance) {

--- a/src/test/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceUpdateMyParkingTest.java
+++ b/src/test/java/com/igrowker/feature/parkify/features/parking/service/ParkingServiceUpdateMyParkingTest.java
@@ -1,0 +1,268 @@
+package com.igrowker.feature.parkify.features.parking.service;
+
+import com.igrowker.feature.parkify.exception.OwnerNotFoundException;
+import com.igrowker.feature.parkify.exception.ParkingNotFoundException;
+import com.igrowker.feature.parkify.features.auth.entities.AuthUser;
+import com.igrowker.feature.parkify.features.auth.repository.AuthUserRepository;
+import com.igrowker.feature.parkify.features.parking.dto.request.UpdateMyParkingRequest;
+import com.igrowker.feature.parkify.features.parking.dto.response.ParkingResponse;
+import com.igrowker.feature.parkify.features.parking.entities.Parking;
+import com.igrowker.feature.parkify.features.parking.repository.ParkingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ParkingServiceImpl - updateMyParking (with ID) Unit Tests")
+class ParkingServiceUpdateMyParkingWithIdTest {
+
+    private static final String OWNER_EMAIL_EXISTS = "owner.update@test.com";
+    private static final String OWNER_EMAIL_NOT_FOUND = "owner.update.notfound@test.com";
+    private static final Long OWNER_ID = 1L;
+    private static final Long PARKING_ID = 10L;
+    private static final Long NON_EXISTENT_PARKING_ID = 99L;
+    private static final int INITIAL_CAPACITY = 20;
+    private static final int INITIAL_AVAILABLE_SPOTS = 10;
+
+    @Mock
+    private ParkingRepository parkingRepository;
+    @Mock
+    private AuthUserRepository authUserRepository;
+    @InjectMocks
+    private ParkingServiceImpl parkingService;
+
+    @Captor
+    private ArgumentCaptor<Parking> parkingCaptor;
+
+    private AuthUser testOwner;
+    private Parking existingParking;
+    private UpdateMyParkingRequest validUpdateRequest;
+    private UpdateMyParkingRequest invalidCapacityRequest;
+    private UpdateMyParkingRequest sameCapacityRequest;
+
+    @BeforeEach
+    void setUp() {
+        testOwner = new AuthUser();
+        testOwner.setId(OWNER_ID);
+        testOwner.setEmail(OWNER_EMAIL_EXISTS);
+        testOwner.setUsername("Test Update Owner");
+        testOwner.setContactPhone("123456789");
+
+        existingParking = Parking.builder()
+                .id(PARKING_ID)
+                .ownerId(OWNER_ID)
+                .name("Old Name")
+                .address("Old Address")
+                .latitude(10.0)
+                .longitude(10.0)
+                .description("Old Description")
+                .capacity(INITIAL_CAPACITY)
+                .availableSpots(INITIAL_AVAILABLE_SPOTS)
+                .hourlyRate(5.0)
+                .workingHours("Old Hours")
+                .parkingPhone("Old Phone")
+                .parkingImageUrl("Old URL")
+                .build();
+
+        validUpdateRequest = new UpdateMyParkingRequest(
+                "New Name",
+                "New Address",
+                20.0,
+                20.0,
+                "New Description",
+                25,
+                6.0,
+                "New Hours",
+                "New Phone",
+                "New URL"
+        );
+
+        invalidCapacityRequest = new UpdateMyParkingRequest(
+                "Invalid Cap Name", "Invalid Cap Address", 30.0, 30.0,
+                "Desc", 5, 7.0, "Hours", null, null
+        );
+
+        sameCapacityRequest = new UpdateMyParkingRequest(
+                "Same Cap Name", "Same Cap Address", 40.0, 40.0,
+                "Desc", INITIAL_CAPACITY, 8.0, "Hours", null, null
+        );
+    }
+
+    @Nested
+    @DisplayName("Success Scenarios")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("Should update parking successfully when owner, parking exist, owner owns it, and request is valid")
+        void shouldUpdateParkingSuccessfully_whenAllConditionsMet() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findById(PARKING_ID)).thenReturn(Optional.of(existingParking));
+            when(parkingRepository.save(any(Parking.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            ParkingResponse response = parkingService.updateMyParking(OWNER_EMAIL_EXISTS, PARKING_ID, validUpdateRequest);
+
+            verify(authUserRepository, times(1)).findByEmail(OWNER_EMAIL_EXISTS);
+            verify(parkingRepository, times(1)).findById(PARKING_ID);
+            verify(parkingRepository, times(1)).save(parkingCaptor.capture());
+            verifyNoMoreInteractions(authUserRepository, parkingRepository);
+
+            Parking capturedParking = parkingCaptor.getValue();
+
+            assertAll("Captured Entity Fields Update",
+                    () -> assertThat(capturedParking.getId()).isEqualTo(PARKING_ID),
+                    () -> assertThat(capturedParking.getOwnerId()).isEqualTo(OWNER_ID),
+                    () -> assertThat(capturedParking.getName()).isEqualTo(validUpdateRequest.name()),
+                    () -> assertThat(capturedParking.getAddress()).isEqualTo(validUpdateRequest.address()),
+                    () -> assertThat(capturedParking.getLatitude()).isEqualTo(validUpdateRequest.latitude()),
+                    () -> assertThat(capturedParking.getLongitude()).isEqualTo(validUpdateRequest.longitude()),
+                    () -> assertThat(capturedParking.getDescription()).isEqualTo(validUpdateRequest.description()),
+                    () -> assertThat(capturedParking.getCapacity()).isEqualTo(validUpdateRequest.capacity()),
+                    () -> assertThat(capturedParking.getHourlyRate()).isEqualTo(validUpdateRequest.hourlyRate()),
+                    () -> assertThat(capturedParking.getWorkingHours()).isEqualTo(validUpdateRequest.workingHours()),
+                    () -> assertThat(capturedParking.getParkingPhone()).isEqualTo(validUpdateRequest.parkingPhone()),
+                    () -> assertThat(capturedParking.getParkingImageUrl()).isEqualTo(validUpdateRequest.parkingImageUrl()),
+                    () -> assertThat(capturedParking.getAvailableSpots()).isEqualTo(INITIAL_AVAILABLE_SPOTS) // Не меняется
+            );
+
+            assertAll("Response DTO Fields",
+                    () -> assertThat(response).isNotNull(),
+                    () -> assertThat(response.getId()).isEqualTo(PARKING_ID),
+                    () -> assertThat(response.getName()).isEqualTo(validUpdateRequest.name()),
+                    () -> assertThat(response.getCurrentAvailability()).isEqualTo(INITIAL_AVAILABLE_SPOTS)
+            );
+        }
+
+        @Test
+        @DisplayName("Should update successfully and skip capacity validation when capacity is not changed")
+        void shouldSkipCapacityCheck_whenCapacityIsNotChanged() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findById(PARKING_ID)).thenReturn(Optional.of(existingParking));
+            when(parkingRepository.save(any(Parking.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            ParkingResponse response = parkingService.updateMyParking(OWNER_EMAIL_EXISTS, PARKING_ID, sameCapacityRequest);
+
+            verify(parkingRepository).save(parkingCaptor.capture());
+            Parking captured = parkingCaptor.getValue();
+
+            assertThat(captured.getCapacity()).isEqualTo(INITIAL_CAPACITY);
+            assertThat(captured.getName()).isEqualTo(sameCapacityRequest.name());
+            assertThat(response.getCapacity()).isEqualTo(INITIAL_CAPACITY);
+            assertThat(response.getName()).isEqualTo(sameCapacityRequest.name());
+        }
+    }
+
+    @Nested
+    @DisplayName("Failure Scenarios")
+    class FailureTests {
+
+        @Test
+        @DisplayName("Should throw OwnerNotFoundException when owner email does not exist")
+        void shouldThrowOwnerNotFoundException_whenOwnerEmailDoesNotExist() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_NOT_FOUND)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> parkingService
+                    .updateMyParking(OWNER_EMAIL_NOT_FOUND, PARKING_ID, validUpdateRequest))
+                    .isInstanceOf(OwnerNotFoundException.class)
+                    .hasMessageContaining(OWNER_EMAIL_NOT_FOUND);
+            verify(parkingRepository, never()).findById(anyLong());
+            verify(parkingRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw ParkingNotFoundException when parking ID does not exist")
+        void shouldThrowParkingNotFoundException_whenParkingIdDoesNotExist() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findById(NON_EXISTENT_PARKING_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> parkingService
+                    .updateMyParking(OWNER_EMAIL_EXISTS, NON_EXISTENT_PARKING_ID, validUpdateRequest))
+                    .isInstanceOf(ParkingNotFoundException.class)
+                    .hasMessageContaining(String.valueOf(NON_EXISTENT_PARKING_ID));
+
+            verify(parkingRepository, times(1)).findById(NON_EXISTENT_PARKING_ID);
+            verify(parkingRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw AccessDeniedException when owner tries to update parking they don't own")
+        void shouldThrowAccessDeniedException_whenUpdatingNotOwnedParking() {
+            final long anotherOwnerId = OWNER_ID + 1;
+            existingParking.setOwnerId(anotherOwnerId);
+
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findById(PARKING_ID)).thenReturn(Optional.of(existingParking));
+
+            assertThatThrownBy(() -> parkingService
+                    .updateMyParking(OWNER_EMAIL_EXISTS, PARKING_ID, validUpdateRequest))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessageContaining(String.format(
+                            "User %s is not authorized to modify parking with id %d", OWNER_EMAIL_EXISTS, PARKING_ID
+                    ));
+
+            verify(parkingRepository, times(1)).findById(PARKING_ID);
+            verify(parkingRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when requested capacity is lower than current available spots")
+        void shouldThrowIllegalArgumentException_whenCapacityIsLowerThanAvailableSpots() {
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findById(PARKING_ID)).thenReturn(Optional.of(existingParking));
+
+            assertThatThrownBy(() -> parkingService
+                    .updateMyParking(OWNER_EMAIL_EXISTS, PARKING_ID, invalidCapacityRequest))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(String.format(
+                            "Cannot set capacity (%d) lower than current available spots (%d)",
+                            invalidCapacityRequest.capacity(), existingParking.getAvailableSpots()
+                    ));
+
+            verify(parkingRepository, times(1)).findById(PARKING_ID);
+            verify(parkingRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when capacity is lower and availableSpots is null")
+        void shouldThrowIllegalArgumentException_whenCapacityIsLowerAndAvailableIsNull() {
+            existingParking.setAvailableSpots(null);
+            existingParking.setCapacity(15);
+            UpdateMyParkingRequest lowCapacityRequest = new UpdateMyParkingRequest(
+                    "Low Cap", "Low Addr", 1.0, 1.0, "Desc", 10, 1.0, "H", null, null
+            );
+
+            when(authUserRepository.findByEmail(OWNER_EMAIL_EXISTS)).thenReturn(Optional.of(testOwner));
+            when(parkingRepository.findById(PARKING_ID)).thenReturn(Optional.of(existingParking));
+
+            assertThatThrownBy(() -> parkingService
+                    .updateMyParking(OWNER_EMAIL_EXISTS, PARKING_ID, lowCapacityRequest))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(String.format(
+                            "Cannot set capacity (%d) lower than current available spots (%d)",
+                            lowCapacityRequest.capacity(), existingParking.getCapacity()
+                    ));
+
+            verify(parkingRepository, never()).save(any());
+        }
+    }
+}


### PR DESCRIPTION
Este PR introduce el endpoint `PUT /api/v1/parkings/{parkingId}` para permitir a los propietarios autenticados actualizar los detalles de un parking específico que les pertenece. Reemplaza el anterior endpoint `PUT /api/v1/parkings/my`, el cual era ambiguo si un propietario tenía múltiples parkings.

Se ha añadido una **verificación de propiedad** crucial en la capa de servicio (`ParkingServiceImpl`) para asegurar que un usuario solo pueda modificar los parkings que posee, abordando una vulnerabilidad de seguridad identificada durante las pruebas con `curl`.

## Cambios Realizados

*   **ParkingController:**
    *   Se modificó el endpoint `@PutMapping` de `/my` a `/{parkingId}`.
    *   Se añadió `@PathVariable Long parkingId` al método del controlador.
    *   Se actualizaron las anotaciones de Swagger.
*   **ParkingService (Interfaz):**
    *   Se actualizó la firma del método `updateMyParking` para aceptar `parkingId`.
    *   Se actualizó el Javadoc para reflejar el nuevo parámetro y la excepción `AccessDeniedException`.
*   **ParkingServiceImpl:**
    *   Se modificó la implementación de `updateMyParking` para buscar el parking por `parkingId`.
    *   Se añadió una llamada al método `ensureOwnership` (o lógica equivalente) para verificar que `parking.getOwnerId()` coincide con el `owner.getId()` del usuario autenticado. Se lanza `AccessDeniedException` si no coinciden.
    *   La lógica restante de actualización y validación de `capacity` permanece.
*   **SecurityConfig:**
    *   Se actualizó la regla de autorización para proteger `PUT /api/v1/parkings/{parkingId}` y requerir el rol `OWNER`.
*   **Pruebas Unitarias:**
    *   Se actualizaron los tests existentes para `updateMyParking` para usar `findById` y pasar `parkingId`.
    *   Se añadió un nuevo test para verificar específicamente que se lanza `AccessDeniedException` al intentar actualizar un parking ajeno.
*   **Pruebas `curl`:**
    *   Se actualizó el script `test_api.sh` para usar el nuevo endpoint `PUT /api/v1/parkings/{parkingId}`.
    *   Se verificó que la prueba de seguridad (actualizar parking ajeno) ahora pasa correctamente (devuelve 403).

## Cómo Probar

1.  Ejecutar las pruebas unitarias (`mvn test`).
2.  Ejecutar el script `curl` actualizado (`./test_api.sh`). Verificar que la sección `2.bis` pasa, especialmente el test `2.bis.4.1` (debe devolver 403).
3.  (Opcional) Probar manualmente con Postman o similar:
    *   Autenticarse como Propietario 1.
    *   Intentar actualizar el Parking ID 1 (éxito, 200 OK).
    *   Intentar actualizar el Parking ID 4 (pertenece a Propietario 2) (fallo, 403 Forbidden).

## Notas Adicionales

*   El endpoint problemático `DELETE /my` no se ha modificado en este PR y requerirá un refactor similar (introducir `DELETE /{parkingId}` con verificación de propiedad) en un futuro PR.
*   Se aborda directamente el requisito del frontend de poder actualizar un parking específico.
___
This PR introduces the `PUT /api/v1/parkings/{parkingId}` endpoint to allow authenticated owners to update the details of a specific parking facility they own. It replaces the previous `PUT /api/v1/parkings/my` endpoint, which was ambiguous if an owner had multiple parkings.

A crucial **ownership check** has been added in the service layer (`ParkingServiceImpl`) to ensure that a user can only modify the parkings they own, addressing a security vulnerability identified during `curl` testing.

## Changes Made

*   **ParkingController:**
    *   Modified the `@PutMapping` endpoint from `/my` to `/{parkingId}`.
    *   Added `@PathVariable Long parkingId` to the controller method.
    *   Updated Swagger annotations.
*   **ParkingService (Interface):**
    *   Updated the `updateMyParking` method signature to accept `parkingId`.
    *   Updated Javadoc to reflect the new parameter and the `AccessDeniedException`.
*   **ParkingServiceImpl:**
    *   Modified the `updateMyParking` implementation to find the parking by `parkingId`.
    *   Added a call to the `ensureOwnership` method (or equivalent logic) to verify that `parking.getOwnerId()` matches the authenticated user's `owner.getId()`. Throws `AccessDeniedException` if they don't match.
    *   The remaining update and `capacity` validation logic persists.
*   **SecurityConfig:**
    *   Updated the authorization rule to protect `PUT /api/v1/parkings/{parkingId}` and require the `OWNER` role.
*   **Unit Tests:**
    *   Updated existing tests for `updateMyParking` to use `findById` and pass `parkingId`.
    *   Added a new test to specifically verify that `AccessDeniedException` is thrown when attempting to update someone else's parking.
*   **`curl` Tests:**
    *   Updated the `test_api.sh` script to use the new `PUT /api/v1/parkings/{parkingId}` endpoint.
    *   Verified that the security test (updating another owner's parking) now passes correctly (returns 403).

## How to Test

1.  Run unit tests (`mvn test`).
2.  Run the updated `curl` script (`./test_api.sh`). Verify that section `2.bis` passes, especially test `2.bis.4.1` (should return 403).
3.  (Optional) Test manually with Postman or similar:
    *   Authenticate as Owner 1.
    *   Attempt to update Parking ID 1 (success, 200 OK).
    *   Attempt to update Parking ID 4 (belongs to Owner 2) (failure, 403 Forbidden).

## Additional Notes

*   The problematic `DELETE /my` endpoint has not been modified in this PR and will require a similar refactor (introducing `DELETE /{parkingId}` with ownership check) in a future PR.
*   Directly addresses the frontend requirement to update a specific parking.